### PR TITLE
Handle `254` and `255` chunks while decoding with helper functions 🏜️

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ const handleChunk255 = (bytes, index, bytesLength) => {
 		throw new DecompressError(
 			createMessage(
 				`The \`bytes\` argument is malformed because it has ${bytesLength} elements.`,
-				`It wants to read from index ${bytesCountIndex} to ${verbatimEnd}.`
+				`It wants to read from index ${verbatimStart} to ${verbatimEnd}.`
 			)
 		)
 	}

--- a/test/compatto.js
+++ b/test/compatto.js
@@ -167,7 +167,7 @@ test('`decompress()` cannot use malformed buffer', (t) => {
 		{
 			instanceOf: DecompressError,
 			message:
-				'The `bytes` argument is malformed because it has 3 elements. It wants to read from index 1 to 53.'
+				'The `bytes` argument is malformed because it has 3 elements. It wants to read from index 2 to 53.'
 		}
 	)
 


### PR DESCRIPTION
Well, as the title says chunks starting with `254` and `255` are handled through helper functions, so that the code is _drier_ (hah!) 🏜️

There was also an incorrect index used for an error message, now it should be fixed.